### PR TITLE
Add uv runner support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,7 @@ Lint Alembic Postgres migrations and report violations as a comment in a GitHub 
 
 - `changed`: Indicates whether any new migrations were found and processed.
 
-## Usage Example
-
-Here is an example of how to use this action in a GitHub workflow:
+## Usage Example (uv)
 
 ```yaml
 name: Lint Alembic Migrations
@@ -28,28 +26,33 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write 
+  pull-requests: write
+
+env:
+  UV_PYTHON: "3.13"
 
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
-      - name: Setup Python
-        uses: actions/setup-python@v5
+      - name: Set up Python and uv
+        uses: astral-sh/setup-uv@v7
         with:
-          python-version-file: 'pyproject.toml'
-          cache: 'poetry'
+          python-version: '3.13'
+          enable-cache: true
 
       - name: Install dependencies
-        run: poetry install
+        run: uv sync
 
       - name: Lint Alembic Migrations
-        uses: remedyproduct/alembic-squawk-action@v0.0.1
+        uses: remedyproduct/alembic-squawk-action@v0.0.3
         with:
           migrations_path: 'migrations'
           alembic_config: 'alembic.ini'
-          runner: 'poetry'
+          runner: 'uv'
 ```
+
+If you prefer Poetry or Pipenv, set `runner` to `poetry` or `pipenv` instead. Leaving `runner` empty uses the system interpreter.

--- a/action.yml
+++ b/action.yml
@@ -37,15 +37,19 @@ runs:
       if: ${{ steps.modified-migrations.outputs.migrations == 'true' }}
       shell: bash
       run: |
-        # Determine the command prefix based on the runner input.
-        if [ -z "${{ inputs.runner }}" ] || [ "${{ inputs.runner }}" = "none" ]; then
+        runner="${{ inputs.runner }}"
+        if [ -z "$runner" ] || [ "$runner" = "none" ]; then
           CMD="python"
           ALEMBIC_CMD="alembic"
+        elif [ "$runner" = "uv" ]; then
+          CMD="uv run python"
+          ALEMBIC_CMD="uv run alembic"
+        elif [ "$runner" = "poetry" ] || [ "$runner" = "pipenv" ] || [ "$runner" = "pdm" ]; then
+          CMD="$runner run python"
+          ALEMBIC_CMD="$runner run alembic"
         else
-          # For tools like pipenv or uv, users might already include "run" in the command.
-          # Here we assume the common case of "poetry", so we add "run".
-          CMD="${{ inputs.runner }} run python"
-          ALEMBIC_CMD="${{ inputs.runner }} run alembic"
+          CMD="$runner python"
+          ALEMBIC_CMD="$runner alembic"
         fi
 
         echo "Using command prefix: $CMD"


### PR DESCRIPTION
## Summary
- detect `runner: uv` and execute Alembic via `uv run`
- keep existing poetry/pipenv defaults and fallback
- document uv usage example and default version in README

This unblocks uv-based workflows (e.g. setup-uv) where Poetry is not installed and the action currently fails with `poetry: command not found`.